### PR TITLE
implement `cd` and `cat`, run `rustfmt`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -218,7 +218,27 @@ fn main() -> Result<()> {
                 // `cat filename`
                 // print the contents of filename to stdout
                 // if it's a directory, print a nice error
-                println!("cat not yet implemented");
+                let elts: Vec<&str> = line.split(' ').collect();
+                let file_to_read = elts[1];
+                let mut found = false;
+                for dir in &dirs {
+                    if dir.1.to_string().eq(file_to_read) && dir.2.to_string() == "Regular" {
+                        found = true;
+                        // fetch the children of the file inode (its content)
+                        let contents = match ext2.read_dir_inode(dir.0) {
+                            Ok(dir_listing) => dir_listing,
+                            Err(_) => {
+                                println!("unable to read cwd");
+                                break;
+                            }
+                        };
+                        println!("{}\t", contents[0].1);
+                        break;
+                    }
+                }
+                if !found {
+                    println!("unable to locate {}", file_to_read);
+                }
             } else if line.starts_with("rm") {
                 // `rm target`
                 // unlink a file or empty directory

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,5 +1,6 @@
 use bitflags::bitflags;
 use null_terminated::NulStr;
+use std::fmt;
 
 #[repr(C)]
 #[derive(Debug)]
@@ -208,6 +209,21 @@ pub enum TypeIndicator {
     Fifo,
     Socket,
     Symlink,
+}
+
+impl fmt::Display for TypeIndicator {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            TypeIndicator::Unknown => write!(f, "Unknown"),
+            TypeIndicator::Regular => write!(f, "Regular"),
+            TypeIndicator::Directory => write!(f, "Directory"),
+            TypeIndicator::Character => write!(f, "Character"),
+            TypeIndicator::Block => write!(f, "Block"),
+            TypeIndicator::Fifo => write!(f, "Fifo"),
+            TypeIndicator::Socket => write!(f, "Socket"),
+            TypeIndicator::Symlink => write!(f, "Symlink"),
+        }
+    }
 }
 
 bitflags! {


### PR DESCRIPTION
I ran the `rustfmt` tool and also added a check that prohibits `cd` into an inode with `Regular` `TypeIndicator`